### PR TITLE
[Fix] 몬스터 풀 매니저에 준비 상태 체크 로직 추가

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -39,7 +39,9 @@
       "Bash(gh --version:*)",
       "Bash(del \"C:\\Users\\happy\\Desktop\\Novelian-Magic-Library-Deffense\\Assets\\ScriptableObjects\\Events\\MonsterEvents.asset\")",
       "Bash(nul)",
-      "Bash(del \"C:\\Users\\happy\\Desktop\\Novelian-Magic-Library-Deffense\\Assets\\ForceRecompile.cs\")"
+      "Bash(del \"C:\\Users\\happy\\Desktop\\Novelian-Magic-Library-Deffense\\Assets\\ForceRecompile.cs\")",
+      "Bash(git stash:*)",
+      "Bash(git checkout:*)"
     ],
     "deny": [],
     "ask": []

--- a/Assets/Scripts/Managers/WaveManager.cs
+++ b/Assets/Scripts/Managers/WaveManager.cs
@@ -179,6 +179,12 @@ namespace NovelianMagicLibraryDefense.Managers
 
         private async UniTaskVoid SpawnEnemy()
         {
+            // LMJ: Wait for pools to be ready before spawning
+            while (!isPoolReady)
+            {
+                await UniTask.Yield();
+            }
+
             int totalMonsters = enemyCount;
             int spawnedCount = 0;
 


### PR DESCRIPTION
## 📝 PR 요약
<!-- 이 PR이 무엇을 하는지 간단히 설명해주세요 -->
- 풀 준비 상태 체크하는 로직이 없어서 간헐적으로 뜨는 Null 참조 오류 해결

## 🔗 관련 Issue
<!-- 관련된 Issue를 연결해주세요 -->
Closes #178 


## 📋 변경 사항
<!-- 주요 변경 내용을 체크리스트로 작성해주세요 -->
- [x] Null 참조 안뜨는지 확인


## 🧪 테스트 완료 항목
<!-- 테스트한 항목을 체크해주세요 -->
- [x] 로컬에서 빌드 및 실행 확인
- [x] 기능 동작 테스트 완료
- [x] 에디터 에러 없음
- [x] 기존 기능에 영향 없음 확인


## 📸 스크린샷 (선택사항)
<!-- 변경 사항을 보여주는 스크린샷이나 GIF가 있다면 첨부해주세요 -->


## 🎯 리뷰 포인트
<!-- 리뷰어가 특별히 확인해야 할 부분이 있다면 작성해주세요 -->


## 🚨 Breaking Changes
<!-- 기존 코드를 변경해야 하는 사항이 있나요? -->
- [x] 없음
- [ ] 있음 (아래 설명)

<!-- Breaking Changes가 있다면 설명해주세요 -->


## 📌 추가 정보
<!-- 기타 리뷰어가 알아야 할 정보가 있다면 작성해주세요 -->


---
### ✅ PR Checklist
- [x] 코딩 컨벤션을 따랐습니다
- [x] 불필요한 주석/디버그 코드를 제거했습니다
- [x] 관련 문서를 업데이트했습니다 (필요시)
- [x] 테스트를 완료했습니다
- [x] 리뷰어를 지정했습니다