### PR TITLE
[Fix] 스킬 교체 시 UI 팝업이 너무 빨리 사라짐

### DIFF
--- a/Assets/01. Scenes/BootScene.unity
+++ b/Assets/01. Scenes/BootScene.unity
@@ -274,7 +274,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   warningPanel: {fileID: 560736447}
   fadeDuration: 0.1
-  displayDuration: 0.5
+  displayDuration: 1
 --- !u!114 &329053013
 MonoBehaviour:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
Updated the displayDuration property from 0.5 to 1 second for the warning panel in BootScene to allow users more time to read warnings.

## 📝 PR 요약
<!-- 이 PR이 무엇을 하는지 간단히 설명해주세요 -->


## 🔗 관련 Issue
<!-- 관련된 Issue를 연결해주세요 -->
Closes #604 


## 📋 변경 사항
<!-- 주요 변경 내용을 체크리스트로 작성해주세요 -->
- [ ] 
- [ ] 
- [ ] 


## 🧪 테스트 완료 항목
<!-- 테스트한 항목을 체크해주세요 -->
- [ ] 로컬에서 빌드 및 실행 확인
- [ ] 기능 동작 테스트 완료
- [ ] 에디터 에러 없음
- [ ] 기존 기능에 영향 없음 확인


## 📸 스크린샷 (선택사항)
<!-- 변경 사항을 보여주는 스크린샷이나 GIF가 있다면 첨부해주세요 -->


## 🎯 리뷰 포인트
<!-- 리뷰어가 특별히 확인해야 할 부분이 있다면 작성해주세요 -->


## 🚨 Breaking Changes
<!-- 기존 코드를 변경해야 하는 사항이 있나요? -->
- [ ] 없음
- [ ] 있음 (아래 설명)

<!-- Breaking Changes가 있다면 설명해주세요 -->


## 📌 추가 정보
<!-- 기타 리뷰어가 알아야 할 정보가 있다면 작성해주세요 -->


---
### ✅ PR Checklist
- [ ] 코딩 컨벤션을 따랐습니다
- [ ] 불필요한 주석/디버그 코드를 제거했습니다
- [ ] 관련 문서를 업데이트했습니다 (필요시)
- [ ] 테스트를 완료했습니다
- [ ] 리뷰어를 지정했습니다